### PR TITLE
Removing the ssd1306 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pico-ssd1306"]
-	path = pico-ssd1306
-	url = https://github.com/Harbys/pico-ssd1306.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,12 @@ project(gauges C CXX ASM)
 # Initialise the Raspberry Pi Pico SDK
 pico_sdk_init()
 
-add_subdirectory(pico-ssd1306)
+# Add the SSD library to the build
+add_subdirectory($ENV{SSD1306_LIB_PATH} ./dep_builds)
 
 # Add executable. Default name is the project name, version 0.1
 add_executable(gauges main.cpp display.cpp voltage.cpp oil.cpp temperature.cpp measurement.cpp SteinhartHart.cpp)
-pico_set_program_name(gauges "gauges")
+pico_set_program_name(gauges "Automotive Gauges")
 pico_set_program_version(gauges "0.1")
 
 pico_enable_stdio_usb(gauges 1)
@@ -35,6 +36,8 @@ target_link_libraries(gauges
         pico_ssd1306
         hardware_i2c
         )
+
+target_include_directories(gauges PUBLIC $ENV{SSD1306_LIB_PATH})
 
 pico_add_extra_outputs(gauges)
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# gauges
-Automotive Gauges Firmware for the RP2040
+# Automotive Gauges
+Automotive Gauges Firmware. This firmware runs on the RP2040 microcontroller using multiple ssd1306 OLED displays. The schematic describes the layout of the gauges circuit.
+
+## Gauge Features
+All gauge readings use a signal level of 5V. A level shifter is used to interface with the RP2040. The following are the supported gauge measurements:
+* Voltage - Calibrated by a voltage divider network
+* Oil Pressure - Using a sender that translates 0-100 PSI to 0-4.5V
+* Coolant Temperature - Using an autometer sender that uses an NTC thermistor
+* Fuel Level - Uses a Ford style fuel sender, calibrated via a voltage divider network
+* Tachometer - The tach circuit contains a signal filter to filter any coil ringback, and an opto-isolated Shmitt trigger to protect the circuit from any unexpected voltage spikes.
+
+## Display Readout
+The display readout consists of 4 SSD1306 OLED displays wired to run in I2C mode. An I2C mux is used so all displays can be addressed.
+
+## Project Dependencies
+The following dependencies are required to build this project:
+* Cmake
+* ARM compiler backend support
+* Raspberry Pi Pico SDK[https://github.com/raspberrypi/pico-sdk]
+* Pico SSD1306 support[https://github.com/Harbys/pico-ssd1306]
+
+## Building the Project
+Set the SDK and library paths:
+```
+$ export PICO_SDK_PATH=/path/to/pico-sdk
+$ export SSD1306_LIB_PATH=/path/to/ssd1306_lib
+```
+
+Switch to the build directory and run the build:
+```
+$ cd build
+$ cmake ..
+$ make

--- a/display.cpp
+++ b/display.cpp
@@ -1,28 +1,23 @@
 #include "display.h"
 #include "pico/stdlib.h"
-#include "pico-ssd1306/ssd1306.h"
-#include "pico-ssd1306/shapeRenderer/ShapeRenderer.h"
-#include "pico-ssd1306/textRenderer/TextRenderer.h"
+#include "ssd1306.h"
+#include "shapeRenderer/ShapeRenderer.h"
+#include "textRenderer/TextRenderer.h"
 #include "hardware/i2c.h"
 
-
-
-Display::Display(uint16_t address, MUX_CHANNEL channel, std::string label, std::string units, bool graphical) :
-    m_address(address),
-    m_channel(channel),
-    m_label(label),
-    m_units(units),
-    m_graphical(graphical)
+Display::Display(uint16_t address, MUX_CHANNEL channel, std::string label, std::string units, bool graphical) : m_address(address),
+                                                                                                                m_channel(channel),
+                                                                                                                m_label(label),
+                                                                                                                m_units(units),
+                                                                                                                m_graphical(graphical)
 {
 
     // Create a new display object
     m_display = std::make_shared<SSD1306>(i2c_default, m_address, Size::W128xH64);
-
 }
 
 Display::~Display()
 {
-
 }
 
 void Display::Clear()
@@ -35,19 +30,19 @@ void Display::SetValue(std::string value)
 {
     SelectChannel();
     value += m_units;
-    drawText(m_display.get(), font_12x16, m_label.c_str(), 5 ,0);
-    drawText(m_display.get(), font_16x32, value.c_str(), 8 ,28);
+    drawText(m_display.get(), font_12x16, m_label.c_str(), 5, 0);
+    drawText(m_display.get(), font_16x32, value.c_str(), 8, 28);
     m_display->sendBuffer();
 }
 
 void Display::SelectChannel()
-{   
+{
     uint8_t buf = static_cast<uint8_t>(m_channel);
     int ret = 0;
-    for(int i=0; i<3; i++)
+    for (int i = 0; i < 3; i++)
     {
         ret = i2c_write_blocking(i2c_default, MUX_ADDRESS, &buf, sizeof(buf), false);
-        if( ret == sizeof(buf) )
+        if (ret == sizeof(buf))
         {
             break;
         }

--- a/display.h
+++ b/display.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 #include <memory>
-#include "pico-ssd1306/ssd1306.h"
+#include "ssd1306.h"
 
 using namespace pico_ssd1306;
 


### PR DESCRIPTION
Removed the ssd1306 submodule and now just depending on the SSD1306_LIB_PATH environment variable.